### PR TITLE
Fix bootloop when switch to art and reboot when cache was full

### DIFF
--- a/msm7x30.mk
+++ b/msm7x30.mk
@@ -194,5 +194,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.strictmode.visual=0 \
     persist.sys.strictmode.disable=1
 
+# This will fix bootloop when switch to art and reboot when cache was full
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.dexopt-data-only=1
+
 # proprietary side of the board
 $(call inherit-product, vendor/semc/msm7x30-common/msm7x30-common-vendor.mk)


### PR DESCRIPTION
This fix set the dalvik-cache and oat temp output back to the data partition.So art have enough space.
