### PR TITLE
Set sdcard as non-removable (workaround for mediaprovider bug)

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/storage_list.xml
+++ b/overlay/frameworks/base/core/res/res/xml/storage_list.xml
@@ -39,7 +39,7 @@
         android:storageDescription="@string/storage_sd_card"
         android:primary="true"
         android:allowMassStorage="true"
-        android:removable="true"
+        android:removable="false"
         android:maxFileSize="4096" />
 
     <storage android:mountPoint="/storage/usbdisk"


### PR DESCRIPTION
Solves this bug:
https://github.com/LegacyXperia/local_manifests/issues/491

Might be a good idea for additional reasons:
- Unmounting a SD card via USB Settings does not unmount swap or sdext,
  which can cause physical damage/instability.
- When USB type is set as MTP (default), the SD card is not removable
  unless configuration is changed to UMS.
