### PR TITLE
releasetools: we don't have a seperate recovery

### DIFF
--- a/releasetools/semc_ota_from_target_files
+++ b/releasetools/semc_ota_from_target_files
@@ -106,7 +106,7 @@ OPTIONS.worker_threads = 3
 OPTIONS.backuptool = False
 OPTIONS.override_device = 'auto'
 OPTIONS.override_prop = False
-OPTIONS.no_separate_recovery = False
+OPTIONS.no_separate_recovery = True
 
 def MostPopularKey(d, default):
   """Given a dict, return the key corresponding to the largest


### PR DESCRIPTION
Building LegacyXperia with this works fine
Building PAC without this results in errors:
"NameError: global name 'boot_img' is not defined"

Change-Id: I908045181d81e292d6bd17892384be39b2f06499
