### PR TITLE
overlay: Disable fading marquee

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -157,7 +157,10 @@
 
     <!-- Device supports LED flashlight -->
     <bool name="config_enableTorch">true</bool>
-
+    
+    <!-- Enables or disables fading edges when marquee is enabled in TextView. -->
+    <bool name="config_ui_enableFadingMarquee">false</bool>
+    
     <!-- Defines the system property to set for performance profile xe: sys.cpu.modes. Leave it
          blank if the device do not support performance profiles -->
     <string name="config_perf_profile_prop" translatable="false">sys.perf.profile</string>


### PR DESCRIPTION
The framerate drops significantly when any comes on screen.
see http://review.cyanogenmod.org/#/c/65454/
