### PR TITLE
Enable dex-preoptimization for overall speedup

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -106,3 +106,14 @@ SOMC_CFG_SENSORS_LIGHT_AS3676_DISABLE_ALS_SWITCH := yes
 
 # CM Hardware tunables
 BOARD_HARDWARE_CLASS := device/semc/msm7x30-common/cmhw
+
+# Enable dex-preoptimization to speed up first boot sequence
+ifeq ($(HOST_OS),linux)
+  ifeq ($(TARGET_BUILD_VARIANT),$(filter $(TARGET_BUILD_VARIANT),user eng))
+    ifeq ($(WITH_DEXPREOPT),)
+      WITH_DEXPREOPT := true
+      WITH_DEXPREOPT_BOOT_IMG_ONLY := false
+    endif
+  endif
+endif
+WITH_DEXPREOPT_BOOT_IMG_ONLY ?= true


### PR DESCRIPTION
Thanks @percy_g2 for the initial commit

PROs:
-- fixes long first boot up times from 10-20min to 4-5min.
-- Later all boots are completed in less than a minute.
-- Overall optimization of dex files of apps and other system files leading to smooth UI and reducing 95% of the lags that were caused.

CONs:
-- Size of the zip goes up by 20-30mb

Performance more important than size zip
