### PR TITLE
msm7x30: disable audio resampler

### DIFF
--- a/msm7x30.mk
+++ b/msm7x30.mk
@@ -173,10 +173,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     use.non-omx.mp3.decoder=false \
     use.non-omx.aac.decoder=false
 
-# Resampler quality
-PRODUCT_PROPERTY_OVERRIDES += \
-    af.resampler.quality=4
-
 # Disable gapless mode
 PRODUCT_PROPERTY_OVERRIDES += \
     audio.gapless.playback.disable=true


### PR DESCRIPTION
See what steve said.
reference: http://review.cyanogenmod.org/#/c/80800/
(notification sounds working now)
